### PR TITLE
Fix for log method references being cached

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,9 +18,8 @@ function getLogLevel() {
 
 exports.setLogLevel = setLogLevel
 exports.getLogLevel = getLogLevel
-exports.debug       = log.debug
-exports.error       = log.error
-exports.info        = log.info
-exports.log         = log.log
-exports.warn        = log.warn
-
+exports.debug       = function () { log.debug.apply(log, arguments) }
+exports.error       = function () { log.error.apply(log, arguments) }
+exports.info        = function () { log.info.apply(log, arguments)  }
+exports.log         = function () { log.log.apply(log, arguments)   }
+exports.warn        = function () { log.warn.apply(log, arguments)  }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@sixleaveakkm/aws-synthetics-logger-local",
-  "version": "0.1.6",
+  "name": "@jessiehernandez/aws-synthetics-logger-local",
+  "version": "0.1.7",
   "description": "dev library for aws synthetics canary",
   "main": "index.js",
   "scripts": {
@@ -12,11 +12,11 @@
     "synthetics",
     "aws"
   ],
-  "author": "sixleaveakkm",
+  "author": "jessiehernandez",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/sixleaveakkm/aws-synthetics-logger-local.git"
+    "url": "git+ssh://git@github.com/jessiehernandez/aws-synthetics-logger-local.git"
   },
   "bugs": {
     "url": "https://github.com/sixleaveakkm/aws-synthetics-logger-local/issues"


### PR DESCRIPTION
When this module is first imported, the references to the methods from `loglevel` are saved. These methods can change after running `setLogLevel` or `setLevel`, but since the method references are cached, any calls to `log.info`, for example , won't do anything, as `log.info` still points to loglevel's `noop` method.

Please ignore the changes in package.json.
